### PR TITLE
Create godot-ci Workflow

### DIFF
--- a/.github/workflows/godot-ci.yml
+++ b/.github/workflows/godot-ci.yml
@@ -1,11 +1,82 @@
-# .github/workflows/ci.yml
-name: CI Workflow
+name: Godot CI
 
 on:
   workflow_call:
+    inputs:
+      godot_version:
+        description: Godot version to use when building the project'
+        required: true
+        default: 4.2.2
+        type: string
 
+      export_name:
+        description: Name of the export
+        required: true
+        default: test-project
+        type: string
+
+      project_path:
+        description: Path to the project
+        required: true
+        default: games/test-project
+        type: string
+       
 jobs:
-  build:
+  export-web:
+    name: Web Export
     runs-on: ubuntu-latest
+    container:
+      image: barichello/godot-ci:4.2.2
     steps:
-      - run: echo "hello world"
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+      - name: Setup
+        run: |
+          mkdir -v -p ~/.local/share/godot/export_templates/
+          mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
+      - name: Web Build
+        run: |
+          mkdir -v -p ${{ inputs.project_path }}/build/web
+          cd ${{ inputs.project_path }}
+          godot --headless --verbose --export-release "HTML5" build/web/index.html
+      - name: Copy netlify.toml
+        run: cp netlify.toml ${{ inputs.project_path }}/build/web
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-build
+          path: ${{ inputs.project_path }}/build/web
+
+  
+  deploy:
+    needs: export-web
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    environment:
+      name: netlify
+      url: ${{ steps.deployment.outputs.deploy-url }}
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: web-build
+          path: ./web-build
+      - name: Deploy to Netlify
+        id: deployment
+        uses: nwtgck/actions-netlify@v3.0
+        with:
+          publish-dir: ./web-build
+          production-branch: main
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions"
+          enable-pull-request-comment: true
+          enable-commit-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 1
+
+    

--- a/.github/workflows/godot-ci.yml
+++ b/.github/workflows/godot-ci.yml
@@ -34,6 +34,7 @@ jobs:
           lfs: true
       - name: Setup
         run: |
+          echo 'oh hai ${{inputs.godot_version}}'
           mkdir -v -p ~/.local/share/godot/export_templates/
           mv /root/.local/share/godot/export_templates/${{inputs.godot_version}}.stable ~/.local/share/godot/export_templates/${{inputs.godot_version}}.stable
       - name: Web Build

--- a/.github/workflows/godot-ci.yml
+++ b/.github/workflows/godot-ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup
         run: |
           mkdir -v -p ~/.local/share/godot/export_templates/
-          mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
+          mv /root/.local/share/godot/export_templates/${{inputs.godot_version}}.stable ~/.local/share/godot/export_templates/${{inputs.godot_version}}.stable
       - name: Web Build
         run: |
           mkdir -v -p ${{ inputs.project_path }}/build/web


### PR DESCRIPTION
## Overview

This change creates a `godot-ci` workflow to build Godot 4.x projects and deploy them to the netlify `watsutatsu-test-godot` site.

## References
- https://github.com/watsutatsu/test-godot/pull/7