### PR TITLE
Adding godot-tests GitHub Workflow

### DIFF
--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -45,6 +45,8 @@ jobs:
           unzip v${GUT_VERION}.zip
           mv Gut-${GUT_VERION}/addons ./
           rm -rf Gut-${GUT_VERION}
+
+          find .
           
       - name: Run Tests
         run: |

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -56,7 +56,7 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::running gut tests"
-          godot --headless -s addons/gut/gut_cmdln.gd --path "$PWD" -gdir=${{ inputs.test_path }} -glog=1 -gexit | tee output.txt
+          godot --headless -s addons/gut/gut_cmdln.gd --path "$PWD" -gdir= -glog=1 -gexit | tee output.txt
           if grep -q "Tests             none" output.txt; then 
             exit 1;
           fi

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -48,6 +48,12 @@ jobs:
           
       - name: Run Tests
         run: |
+        
+          echo "::group::importing project"
           # HACK - See https://github.com/watsutatsu/godot-samples/issues/3#issuecomment-2119308212
           godot --headless --import-stuff --editor --path "$PWD"  --quit-after 15
+          echo "::endgroup::"
+
+          echo "::group::running gut tests"
           godot --headless -s addons/gut/gut_cmdln.gd --path "$PWD" -gdir=${test_path} -glog=1 -gexit
+          echo "::endgroup::"

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -58,7 +58,7 @@ jobs:
           echo "::group::running gut tests"
           godot --headless -s addons/gut/gut_cmdln.gd --path "$PWD" -gdir=${{ inputs.test_path }} -glog=1 -gexit | tee output.txt
           if grep -q "Tests             none" output.txt; then 
+            echo "No tests found!";
             exit 1;
           fi
           echo "::endgroup::"
-          

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -40,8 +40,7 @@ jobs:
           unzip v${GUT_VERION}.zip
           mv Gut-${GUT_VERION}/addons ./
           rm -rf Gut-${GUT_VERION}
-
-          find -type f # DEBUG
+          
       - name: Run Tests
         run: |
           # HACK - See https://github.com/watsutatsu/godot-samples/issues/3#issuecomment-2119308212

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -34,7 +34,7 @@ jobs:
           lfs: true
       - name: Setup GUT
         run: |
-          wget https://github.com/bitwes/Gut/archive/refs/tags/${{ inputs.GUT_VERSION }}.zip
+          wget https://github.com/bitwes/Gut/archive/refs/tags/v${{ inputs.GUT_VERSION }}.zip
           unzip ${{ inputs.GUT_VERSION }}.zip
       - name: Run Tests
         run: |

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -1,0 +1,43 @@
+name: Godot CI
+
+on:
+  workflow_call:
+    inputs:
+      godot_version:
+        description: Godot version to use when building the project'
+        required: true
+        default: 4.2.2
+        type: string
+
+      gut_version:
+        description: GUT version to use when running tests
+        required: true
+        default: 9.2.1
+        type: string
+
+      project_path:
+        description: Path to the project
+        required: true
+        default: games/test-project
+        type: string
+       
+jobs:
+  export-web:
+    name: Web Export
+    runs-on: ubuntu-latest
+    container:
+      image: barichello/godot-ci:4.2.2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+      - name: Setup GUT
+        run: |
+          wget https://github.com/bitwes/Gut/archive/refs/tags/${{ inputs.GUT_VERSION }}.zip
+          unzip ${{ inputs.GUT_VERSION }}.zip
+      - name: Run Tests
+        run: |
+          # HACK - See https://github.com/watsutatsu/godot-samples/issues/3#issuecomment-2119308212
+          timeout 30s godot --headless --import-stuff --editor --path "$PWD" 
+          godot --headless --verbose --export-release "HTML5" build/web/index.html

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -23,7 +23,6 @@ on:
 
       test_path:
         description: Path to the test folder
-        required: true
         default: res://test/unit
         type: string
        

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -44,5 +44,5 @@ jobs:
       - name: Run Tests
         run: |
           # HACK - See https://github.com/watsutatsu/godot-samples/issues/3#issuecomment-2119308212
-          timeout 30s godot --headless --import-stuff --editor --path "$PWD" 
-          godot --headless --verbose --export-release "HTML5" build/web/index.html
+          godot --headless --import-stuff --editor --path "$PWD"  --quit-after 15
+          godot --headless -s addons/gut/gut_cmdln.gd --path "$PWD" -gdir=res://test/unit -glog=1 -gexit

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -1,4 +1,4 @@
-name: Godot CI
+name: Godot Tests
 
 on:
   workflow_call:
@@ -33,8 +33,13 @@ jobs:
           lfs: true
       - name: Setup GUT
         run: |
-          wget https://github.com/bitwes/Gut/archive/refs/tags/v${{ inputs.GUT_VERSION }}.zip
-          unzip ${{ inputs.GUT_VERSION }}.zip
+          GUT_VERION=${{ inputs.GUT_VERSION }}
+          wget https://github.com/bitwes/Gut/archive/refs/tags/v${GUT_VERION}.zip
+          unzip ${GUT_VERION}.zip
+          mv Gut-${GUT_VERION}/addons ./
+          rm -rf Gut-${GUT_VERION}
+
+          find -type -f # DEBUG
       - name: Run Tests
         run: |
           # HACK - See https://github.com/watsutatsu/godot-samples/issues/3#issuecomment-2119308212

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -56,7 +56,7 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::running gut tests"
-          godot --headless -s addons/gut/gut_cmdln.gd --path "$PWD" -gdir= -glog=1 -gexit | tee output.txt
+          godot --headless -s addons/gut/gut_cmdln.gd --path "$PWD" -gdir=${{ inputs.test_path }} -glog=1 -gexit | tee output.txt
           if grep -q "Tests             none" output.txt; then 
             exit 1;
           fi

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -56,5 +56,5 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::running gut tests"
-          godot --headless -s addons/gut/gut_cmdln.gd --path "$PWD" -gdir=${test_path} -glog=1 -gexit
+          godot --headless -s addons/gut/gut_cmdln.gd --path "$PWD" -gdir=${{ inputs.test_path }} -glog=1 -gexit
           echo "::endgroup::"

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -56,5 +56,8 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::running gut tests"
-          godot --headless -s addons/gut/gut_cmdln.gd --path "$PWD" -gdir=${{ inputs.test_path }} -glog=1 -gexit
+          godot --headless -s addons/gut/gut_cmdln.gd --path "$PWD" -gdir=${{ inputs.test_path }} -glog=1 -gexit | tee output.txt
+          if grep -q "Tests             none" output.txt; then 
+            exit 1;
+          fi
           echo "::endgroup::"

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           GUT_VERION=${{ inputs.GUT_VERSION }}
           wget https://github.com/bitwes/Gut/archive/refs/tags/v${GUT_VERION}.zip
-          unzip ${GUT_VERION}.zip
+          unzip v${GUT_VERION}.zip
           mv Gut-${GUT_VERION}/addons ./
           rm -rf Gut-${GUT_VERION}
 

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Run Tests
         run: |
           godot --version
+          find .
           echo "::group::importing project"
           # HACK - See https://github.com/watsutatsu/godot-samples/issues/3#issuecomment-2119308212
           godot --headless --import-stuff --editor --path "$PWD"  --quit-after 15

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Setup GUT
         run: |
           GUT_VERION=${{ inputs.GUT_VERSION }}
+
+          cd ${{ inputs.project_path }}
           wget https://github.com/bitwes/Gut/archive/refs/tags/v${GUT_VERION}.zip
           unzip v${GUT_VERION}.zip
           mv Gut-${GUT_VERION}/addons ./

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -50,7 +50,7 @@ jobs:
           
       - name: Run Tests
         run: |
-        
+          godot --version
           echo "::group::importing project"
           # HACK - See https://github.com/watsutatsu/godot-samples/issues/3#issuecomment-2119308212
           godot --headless --import-stuff --editor --path "$PWD"  --quit-after 15

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -61,3 +61,4 @@ jobs:
             exit 1;
           fi
           echo "::endgroup::"
+          

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -20,6 +20,12 @@ on:
         required: true
         default: games/test-project
         type: string
+
+      test_path:
+        description: Path to the test folder
+        required: true
+        default: res://test/unit
+        type: string
        
 jobs:
   godot-tests:
@@ -45,4 +51,4 @@ jobs:
         run: |
           # HACK - See https://github.com/watsutatsu/godot-samples/issues/3#issuecomment-2119308212
           godot --headless --import-stuff --editor --path "$PWD"  --quit-after 15
-          godot --headless -s addons/gut/gut_cmdln.gd --path "$PWD" -gdir=res://test/unit -glog=1 -gexit
+          godot --headless -s addons/gut/gut_cmdln.gd --path "$PWD" -gdir=${test_path} -glog=1 -gexit

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -22,8 +22,7 @@ on:
         type: string
        
 jobs:
-  export-web:
-    name: Web Export
+  godot-tests:
     runs-on: ubuntu-latest
     container:
       image: barichello/godot-ci:4.2.2

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -39,7 +39,7 @@ jobs:
           mv Gut-${GUT_VERION}/addons ./
           rm -rf Gut-${GUT_VERION}
 
-          find -type -f # DEBUG
+          find -type f # DEBUG
       - name: Run Tests
         run: |
           # HACK - See https://github.com/watsutatsu/godot-samples/issues/3#issuecomment-2119308212

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Run Tests
         run: |
           godot --version
-          find .
+          cd ${{ inputs.project_path }}
           echo "::group::importing project"
           # HACK - See https://github.com/watsutatsu/godot-samples/issues/3#issuecomment-2119308212
           godot --headless --import-stuff --editor --path "$PWD"  --quit-after 15

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -37,21 +37,19 @@ jobs:
         with:
           lfs: true
       - name: Setup GUT
+        working-directory: ${{ inputs.project_path }}
         run: |
           GUT_VERION=${{ inputs.GUT_VERSION }}
 
-          cd ${{ inputs.project_path }}
           wget https://github.com/bitwes/Gut/archive/refs/tags/v${GUT_VERION}.zip
           unzip v${GUT_VERION}.zip
           mv Gut-${GUT_VERION}/addons ./
           rm -rf Gut-${GUT_VERION}
-
-          find .
           
       - name: Run Tests
+        working-directory: ${{ inputs.project_path }}
         run: |
           godot --version
-          cd ${{ inputs.project_path }}
           echo "::group::importing project"
           # HACK - See https://github.com/watsutatsu/godot-samples/issues/3#issuecomment-2119308212
           godot --headless --import-stuff --editor --path "$PWD"  --quit-after 15

--- a/.github/workflows/godot-tests.yml.md
+++ b/.github/workflows/godot-tests.yml.md
@@ -1,0 +1,30 @@
+## godot-ci.yml.md
+
+This workflow automatically downloads GUT and runs the test suite for a Godot game.
+
+### Usage
+
+```yaml
+name: Build and Deploy
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+
+jobs:
+  godot-ci:
+    uses: watsutatsu/actions/.github/workflows/godot-ci.yml@main
+    with:
+      godot_version: 4.2.2
+      export_name: test-project
+      project_path: games/test-project
+    secrets: inherit
+```
+
+## References
+- https://github.com/watsutatsu/test-godot/pull/7

--- a/.github/workflows/godot-tests.yml.md
+++ b/.github/workflows/godot-tests.yml.md
@@ -1,8 +1,16 @@
-## godot-ci.yml.md
+# Godot CI Workflow
 
-This workflow automatically downloads GUT and runs the test suite for a Godot game.
+This workflow automatically downloads GUT (Godot Unit Test) and runs the test suite for a Godot game. It is designed to streamline the process of continuous integration (CI) for your Godot projects by ensuring that your tests are run automatically whenever changes are pushed or pull requests are opened.
 
-### Usage
+### Prerequisites
+
+Before using this workflow, ensure that:
+- You have a Godot project with a test suite configured using GUT.
+- Your repository is set up with the necessary directories and files for running Godot and GUT.
+
+### Basic Usage
+
+To use this workflow in your GitHub Actions, create a file named `.github/workflows/godot-tests.yml` in your repository with the following content:
 
 ```yaml
 name: godot-tests
@@ -15,12 +23,43 @@ on:
 
 jobs:
   godot-ci:
-    uses: watsutatsu/actions/.github/workflows/godot-tests.yml@apaz/godot-tests-1
+    uses: watsutatsu/actions/.github/workflows/godot-tests.yml@main
+```
+
+### Customizing the Workflow
+
+You can customize the workflow by passing parameters to fit your project's specific requirements. Here are some of the parameters you can use:
+
+- **`gut_version`**: Specify the version of GUT to use for running your tests. Ensure that this version is compatible with your Godot version.
+- **`godot_version`**: Specify the version of Godot to use for running your project and tests.
+- **`project_path`**: Specify the relative path to your Godot project within the repository.
+
+Here is an example of a customized workflow configuration:
+
+```yaml
+name: godot-tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  godot-ci:
+    uses: watsutatsu/actions/.github/workflows/godot-tests.yml@main
     with:
       gut_version: 9.2.1
       godot_version: 4.2.2
       project_path: games/main
 ```
 
+### Conclusion
+
+Using this CI workflow ensures that your Godot project's tests are automatically executed on every push or pull request, helping you catch issues early and maintain code quality.
+
 ## References
-- https://github.com/watsutatsu/test-godot/pull/7
+
+- [Godot Unit Test (GUT) Documentation](https://github.com/bitwes/Gut)
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)
+- [Example Pull Request using this workflow](https://github.com/watsutatsu/test-godot/pull/7)

--- a/.github/workflows/godot-tests.yml.md
+++ b/.github/workflows/godot-tests.yml.md
@@ -5,7 +5,7 @@ This workflow automatically downloads GUT and runs the test suite for a Godot ga
 ### Usage
 
 ```yaml
-name: Build and Deploy
+name: godot-tests
 
 on:
   pull_request:
@@ -13,17 +13,13 @@ on:
     branches:
       - main
 
-permissions:
-  pull-requests: write
-
 jobs:
   godot-ci:
-    uses: watsutatsu/actions/.github/workflows/godot-ci.yml@main
+    uses: watsutatsu/actions/.github/workflows/godot-tests.yml@apaz/godot-tests-1
     with:
+      gut_version: 9.2.1
       godot_version: 4.2.2
-      export_name: test-project
-      project_path: games/test-project
-    secrets: inherit
+      project_path: games/main
 ```
 
 ## References


### PR DESCRIPTION
## Overview

This pull request adds a common `godot-tests` workflow

- Downloads the GUT addon and adds it to the game project
- Prepares the imports for the Godot project
- Runs the GUT test suite for the project

## References
- https://github.com/watsutatsu/godot-samples/commit/2d08070bde077d0b4aa1c3efef472ff886ec4093
- https://github.com/watsutatsu/godot-samples/tree/main/games/simple-gut
- https://github.com/watsutatsu/godot-base/issues/8 https://github.com/watsutatsu/godot-base/issues/6